### PR TITLE
Add support for the latest gleam_stdlib (v0.60.0)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: erlef/setup-beam@v1
         with:
           otp-version: "27"
-          gleam-version: "1.7.0"
+          gleam-version: "1.10.0"
           rebar3-version: "3"
           # elixir-version: "1.15.4"
       - run: gleam deps download

--- a/gleam.toml
+++ b/gleam.toml
@@ -13,7 +13,7 @@ links = [{ title = "Website", href = "https://gleam.run" }]
 # https://gleam.run/writing-gleam/gleam-toml/.
 
 [dependencies]
-gleam_stdlib = ">= 0.46.0 and < 1.0.0"
+gleam_stdlib = ">= 0.60.0 and < 1.0.0"
 gleam_regexp = ">= 1.0.0 and < 2.0.0"
 gleam_time = ">= 1.0.0 and < 2.0.0"
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -3,13 +3,13 @@
 
 packages = [
   { name = "gleam_regexp", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_regexp", source = "hex", outer_checksum = "7F5E0C0BBEB3C58E57C9CB05FA9002F970C85AD4A63BA1E55CBCB35C15809179" },
-  { name = "gleam_stdlib", version = "0.55.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "32D8F4AE03771516950047813A9E359249BD9FBA5C33463FDB7B953D6F8E896B" },
+  { name = "gleam_stdlib", version = "0.60.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "621D600BB134BC239CB2537630899817B1A42E60A1D46C5E9F3FAE39F88C800B" },
   { name = "gleam_time", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_time", source = "hex", outer_checksum = "7549892CE3CC267EB733E009FDBADBFA860FAD3D05E0F2A44FD03DADBA344365" },
   { name = "gleeunit", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "0E6C83834BA65EDCAAF4FE4FB94AC697D9262D83E6F58A750D63C9F6C8A9D9FF" },
 ]
 
 [requirements]
 gleam_regexp = { version = ">= 1.0.0 and < 2.0.0" }
-gleam_stdlib = { version = ">= 0.46.0 and < 1.0.0" }
+gleam_stdlib = { version = ">= 0.60.0 and < 1.0.0" }
 gleam_time = { version = ">= 1.0.0 and < 2.0.0" }
 gleeunit = { version = ">= 1.0.0 and < 2.0.0" }

--- a/src/tempo.gleam
+++ b/src/tempo.gleam
@@ -914,6 +914,9 @@ pub type DateTime {
   LocalDateTime(date: Date, time: Time, offset: Offset, tz: TimeZoneProvider)
 }
 
+/// starting point of unix timestamps
+pub const unix_epoch = DateTime(Date(0), TimeOfDay(0), utc)
+
 /// A type for external packages to provide so that datetimes can be converted
 /// between timezones. The package `gtz` was created to provide this and must
 /// be added as a project dependency separately.

--- a/src/tempo.gleam
+++ b/src/tempo.gleam
@@ -914,7 +914,7 @@ pub type DateTime {
   LocalDateTime(date: Date, time: Time, offset: Offset, tz: TimeZoneProvider)
 }
 
-/// starting point of unix timestamps
+@internal
 pub const unix_epoch = DateTime(Date(0), TimeOfDay(0), utc)
 
 /// A type for external packages to provide so that datetimes can be converted

--- a/src/tempo/date.gleam
+++ b/src/tempo/date.gleam
@@ -480,13 +480,13 @@ pub fn from_calendar_date(
 /// ## Examples
 ///
 /// ```gleam
-/// dynamic.from("2024-06-21")
+/// dynamic.string("2024-06-21")
 /// |> date.from_dynamic_string
 /// // -> Ok(date.literal("2024-06-21"))
 /// ```
 ///
 /// ```gleam
-/// dynamic.from("153")
+/// dynamic.string("153")
 /// |> datetime.from_dynamic_string
 /// // -> Error([
 /// //   decode.DecodeError(

--- a/src/tempo/date.gleam
+++ b/src/tempo/date.gleam
@@ -1,31 +1,31 @@
 //// Functions to use with the `Date` type in Tempo.
-//// 
+////
 //// ## Example
-//// 
+////
 //// ```gleam
 //// import tempo/date
-//// 
+////
 //// pub fn main() {
 ////   date.literal("2024-06-21")
 ////   |> date.to_string
 ////   // -> "2024-06-21"
-//// 
+////
 ////   date.parse("06/21/2024", tempo.CustomDate("MM/DD/YYYY"))
 ////   |> date.to_string
 ////   // -> "2024-06-21"
-//// 
+////
 ////   date.current_local()
 ////   |> date.to_string
 ////   // -> "2024-10-09"
 //// }
 //// ```
-//// 
+////
 //// ```gleam
 //// import tempo/date
-//// 
+////
 //// pub fn is_older_than_a_week(date_str: String) {
 ////   let date = date.from_string(date_str)
-//// 
+////
 ////   date
 ////   |> date.is_earlier(
 ////      than: date |> date.subtract(days: 7)
@@ -59,14 +59,14 @@ pub type DayOfWeek {
 }
 
 /// Creates a new date and validates it.
-/// 
+///
 /// ## Examples
-/// 
+///
 /// ```gleam
 /// date.new(2024, 6, 13)
 /// // -> Ok(date.literal("2024-06-13"))
 /// ```
-/// 
+///
 /// ```gleam
 /// date.new(2024, 6, 31)
 /// // -> Error(tempo_error.DateOutOfBounds)
@@ -83,24 +83,24 @@ pub fn new(
 /// the string is invalid. Accepted formats are `YYYY-MM-DD`, `YYYY-M-D`,
 /// `YYYY/MM/DD`, `YYYY/M/D`, `YYYY.MM.DD`, `YYYY.M.D`, `YYYY_MM_DD`,
 /// `YYYY_M_D`, `YYYY MM DD`, `YYYY M D`, or `YYYYMMDD`.
-/// 
-/// Useful for declaring date literals that you know are valid within your  
+///
+/// Useful for declaring date literals that you know are valid within your
 /// program.
-/// 
+///
 /// ## Examples
-/// 
+///
 /// ```gleam
 /// date.literal("2024-06-13")
 /// |> date.to_string
 /// // -> "2024-06-13"
 /// ```
-/// 
+///
 /// ```gleam
 /// date.literal("20240613")
 /// |> date.to_string
 /// // -> "2024-06-13"
 /// ```
-/// 
+///
 /// ```gleam
 /// date.literal("2409")
 /// // -> panic
@@ -120,9 +120,9 @@ pub fn literal(date: String) -> tempo.Date {
 }
 
 /// Gets the current local date of the host.
-/// 
+///
 /// ## Examples
-/// 
+///
 /// ```gleam
 /// date.current_local()
 /// |> date.to_string
@@ -133,9 +133,9 @@ pub fn current_local() {
 }
 
 /// Gets the current UTC date of the host.
-/// 
+///
 /// ## Examples
-/// 
+///
 /// ```gleam
 /// date.current_utc()
 /// |> date.to_string
@@ -146,9 +146,9 @@ pub fn current_utc() {
 }
 
 /// Gets the year value of a date.
-/// 
+///
 /// ## Examples
-/// 
+///
 /// ```gleam
 /// date.literal("2024-06-13")
 /// |> date.get_year
@@ -159,9 +159,9 @@ pub fn get_year(date: tempo.Date) -> Int {
 }
 
 /// Gets the month value of a date.
-/// 
+///
 /// ## Examples
-/// 
+///
 /// ```gleam
 /// date.literal("2024-06-13")
 /// |> date.get_month
@@ -172,9 +172,9 @@ pub fn get_month(date: tempo.Date) -> calendar.Month {
 }
 
 /// Gets the day value of a date.
-/// 
+///
 /// ## Examples
-/// 
+///
 /// ```gleam
 /// date.literal("2024-06-13")
 /// |> date.get_day
@@ -185,9 +185,9 @@ pub fn get_day(date: tempo.Date) -> Int {
 }
 
 /// Gets the month value of a date.
-/// 
+///
 /// ## Examples
-/// 
+///
 /// ```gleam
 /// date.literal("2024-06-13")
 /// |> date.get_month_year
@@ -197,22 +197,22 @@ pub fn get_month_year(date: tempo.Date) -> tempo.MonthYear {
   date |> tempo.date_get_month_year
 }
 
-/// Parses a date string in the format `YYYY-MM-DD`, `YYYY-M-D`, `YYYY/MM/DD`, 
+/// Parses a date string in the format `YYYY-MM-DD`, `YYYY-M-D`, `YYYY/MM/DD`,
 /// `YYYY/M/D`, `YYYY.MM.DD`, `YYYY.M.D`, `YYYY_MM_DD`, `YYYY_M_D`, `YYYY MM DD`,
 /// `YYYY M D`, or `YYYYMMDD`.
-/// 
+///
 /// ## Examples
-/// 
+///
 /// ```gleam
 /// date.from_string("2024-06-13")
 /// // -> Ok(date.literal("2024-06-13"))
 /// ```
-/// 
+///
 /// ```gleam
 /// date.from_string("20240613")
 /// // -> Ok(date.literal("2024-06-13"))
 /// ```
-/// 
+///
 /// ```gleam
 /// date.from_string("2409")
 /// // -> Error(tempo_error.DateInvalidFormat)
@@ -259,9 +259,9 @@ fn split_int_tuple(
 }
 
 /// Returns a string representation of a date value in the format `YYYY-MM-DD`.
-/// 
+///
 /// ## Examples
-/// 
+///
 /// ```gleam
 /// date.literal("2024-06-13")
 /// |> date.to_string
@@ -272,26 +272,26 @@ pub fn to_string(date: tempo.Date) -> String {
 }
 
 /// Parses a date string in the provided format. Always prefer using
-/// this over `parse_any`. All parsed formats must have all parts of a date. 
-/// 
+/// this over `parse_any`. All parsed formats must have all parts of a date.
+///
 /// Values can be escaped by putting brackets around them, like "[Hello!] YYYY".
-/// 
-/// Available directives: YY (two-digit year), YYYY (four-digit year), M (month), 
-/// MM (two-digit month), MMM (short month name), MMMM (full month name), 
+///
+/// Available directives: YY (two-digit year), YYYY (four-digit year), M (month),
+/// MM (two-digit month), MMM (short month name), MMMM (full month name),
 /// D (day of the month), DD (two-digit day of the month),
-/// 
+///
 /// ## Example
-/// 
+///
 /// ```gleam
 /// date.parse("2024/06/08, 13:42:11", "YYYY/MM/DD")
 /// // -> Ok(date.literal("2024-06-08"))
 /// ```
-/// 
+///
 /// ```gleam
 /// date.parse("January 13, 2024", "MMMM DD, YYYY")
 /// // -> Ok(date.literal("2024-01-13"))
 /// ```
-/// 
+///
 /// ```gleam
 /// date.parse("Hi! 2024 11 13", "[Hi!] YYYY M D")
 /// // -> Ok(date.literal("2024-11-13"))
@@ -304,23 +304,23 @@ pub fn parse(
 
   use #(parts, _) <- result.try(
     tempo.consume_format(str, in: format_str)
-    |> result.map_error(tempo_error.DateInvalidFormat(_)),
+    |> result.map_error(tempo_error.DateInvalidFormat),
   )
 
   tempo.find_date(in: parts)
 }
 
-/// Tries to parse a given date string without a known format. It will not 
-/// parse two digit years and will assume the month always comes before the 
+/// Tries to parse a given date string without a known format. It will not
+/// parse two digit years and will assume the month always comes before the
 /// day in a date. Will leave out any time or offset values present.
-/// 
+///
 /// ## Example
-/// 
+///
 /// ```gleam
 /// date.parse_any("2024.06.21 01:32 PM -04:00")
 /// // -> Ok(date.literal("2024-06-21"))
 /// ```
-/// 
+///
 /// ```gleam
 /// date.parse_any("2024.06.21")
 /// // -> Ok(date.literal("2024-06-21"))
@@ -334,9 +334,9 @@ pub fn parse_any(str: String) -> Result(tempo.Date, tempo_error.DateParseError) 
 }
 
 /// Converts a date parse error to a human readable error message.
-/// 
+///
 /// ## Example
-/// 
+///
 /// ```gleam
 /// date.parse_any("01:32 PM")
 /// |> snag.map_error(with: date.describe_parse_error)
@@ -347,33 +347,33 @@ pub fn describe_parse_error(error: tempo_error.DateParseError) -> String {
 }
 
 /// Formats a date value into a string using the provided date format.
-/// 
+///
 /// ## Example
-/// 
+///
 /// ```gleam
 /// datetime.literal("2024-12-26T13:02:01-04:00")
 /// |> datetime.format(tempo.ISO8601Date)
 /// // -> "2024-12-26"
 /// ```
-/// 
+///
 /// ```gleam
 /// datetime.literal("2024-06-21T13:42:11.314-04:00")
 /// |> datetime.format(tempo.CustomDate("ddd @ h:mm A (z)"))
 /// // -> "Fri @ 1:42 PM (-04)"
 /// ```
-/// 
+///
 /// ```gleam
 /// datetime.literal("2024-06-03T09:02:01-04:00")
 /// |> datetime.format(tempo.CustomDate("YY YYYY M MM MMM MMMM D DD d dd ddd"))
 /// // -------------------------------> "24 2024 6 06 Jun June 3 03 1 Mo Mon"
 /// ```
-/// 
-/// ```gleam 
+///
+/// ```gleam
 /// datetime.literal("2024-06-03T09:02:01.014920202-00:00")
 /// |> datetime.format(tempo.CustomDate("dddd SSS SSSS SSSSS Z ZZ z"))
 /// // -> "Monday 014 014920 014920202 -00:00 -0000 Z"
 /// ```
-/// 
+///
 /// ```gleam
 /// datetime.literal("2024-06-03T13:02:01-04:00")
 /// |> datetime.format(tempo.CustomDate(("H HH h hh m mm s ss a A [An ant]"))
@@ -393,11 +393,11 @@ pub fn format(date: tempo.Date, in format: tempo.DateFormat) -> String {
         ..acc
       ]
 
-      // If there is a non-empty subpattern, then the escape 
+      // If there is a non-empty subpattern, then the escape
       // character "[ ... ]" matched, so we should not change anything here.
       regexp.Match(_, [Some(sub)]) -> [sub, ..acc]
 
-      // This case is not expected, not really sure what to do with it 
+      // This case is not expected, not really sure what to do with it
       // so just prepend whatever was found
       regexp.Match(content, _) -> [content, ..acc]
     }
@@ -405,21 +405,21 @@ pub fn format(date: tempo.Date, in format: tempo.DateFormat) -> String {
   |> string.join("")
 }
 
-/// Returns a date value from a tuple of ints if the values represent the 
+/// Returns a date value from a tuple of ints if the values represent the
 /// years, month, and day of a valid date. The year must be greater than 1000.
-/// 
-/// Years less than 1000 are technically valid years, but are not common 
+///
+/// Years less than 1000 are technically valid years, but are not common
 /// and usually indicate that either a non-year value was passed as the year
 /// or a two digit year was passed (which are too abiguous to be confidently
 /// accepted).
-/// 
+///
 /// ## Examples
-/// 
+///
 /// ```gleam
 /// date.from_tuple(#(2024, 6, 13))
 /// // -> Ok(date.literal("2024-06-13"))
 /// ```
-/// 
+///
 /// ```gleam
 /// date.from_tuple(#(98, 6, 13))
 /// // -> Error(tempo_error.DateOutOfBounds)
@@ -431,9 +431,9 @@ pub fn from_tuple(
 }
 
 /// Converts a date out of bounds error to a human readable error message.
-/// 
+///
 /// ## Example
-/// 
+///
 /// ```gleam
 /// date.from_tuple(#(98, 6, 13))
 /// |> snag.map_error(with: date.describe_out_of_bounds_error)
@@ -445,9 +445,9 @@ pub fn describe_out_of_bounds_error(error: tempo_error.DateOutOfBoundsError) {
 
 /// Returns a tuple of ints from a date value that represent the year, month,
 /// and day of the date.
-/// 
+///
 /// ## Examples
-/// 
+///
 /// ```gleam
 /// date.literal("2024-06-14")
 /// |> date.to_tuple
@@ -476,20 +476,20 @@ pub fn from_calendar_date(
 
 /// Checks if a dynamic value is a valid date string, and returns the
 /// date if it is.
-/// 
+///
 /// ## Examples
-/// 
+///
 /// ```gleam
 /// dynamic.from("2024-06-21")
 /// |> date.from_dynamic_string
 /// // -> Ok(date.literal("2024-06-21"))
 /// ```
-/// 
+///
 /// ```gleam
 /// dynamic.from("153")
 /// |> datetime.from_dynamic_string
 /// // -> Error([
-/// //   dynamic.DecodeError(
+/// //   decode.DecodeError(
 /// //     expected: "tempo.Date",
 /// //     found: "Invalid format: 153",
 /// //     path: [],
@@ -498,14 +498,14 @@ pub fn from_calendar_date(
 /// ```
 pub fn from_dynamic_string(
   dynamic_string: dynamic.Dynamic,
-) -> Result(tempo.Date, List(dynamic.DecodeError)) {
+) -> Result(tempo.Date, List(decode.DecodeError)) {
   use date: String <- result.try(
-    // Uses the decode.string function but maintains the dynamic.DecodeError
+    // Uses the decode.string function but maintains the decode.DecodeError
     // return type to maintain API compatibility.
     decode.run(dynamic_string, decode.string)
     |> result.map_error(fn(errs) {
       list.map(errs, fn(err) {
-        dynamic.DecodeError(err.expected, err.found, err.path)
+        decode.DecodeError(err.expected, err.found, err.path)
       })
     }),
   )
@@ -514,7 +514,7 @@ pub fn from_dynamic_string(
     Ok(date) -> Ok(date)
     Error(tempo_error) ->
       Error([
-        dynamic.DecodeError(
+        decode.DecodeError(
           expected: "tempo.Date",
           found: case tempo_error {
             tempo_error.DateInvalidFormat(msg) -> msg
@@ -527,16 +527,16 @@ pub fn from_dynamic_string(
 }
 
 /// Returns the date of a unix timestamp.
-/// 
+///
 /// From https://howardhinnant.github.io/date_algorithms.html#civil_from_days
-/// 
+///
 /// ## Examples
-/// 
+///
 /// ```gleam
 /// date.from_unix_seconds(267_840_000)
 /// // -> date.literal("1978-06-28")
 /// ```
-/// 
+///
 /// I am making this internal because it is created but I am not sure if it
 /// should be part of the public API. I think it is too easy to use incorrectly.
 /// Users should probably use the 'datetime' module's 'from_unix_seconds' function
@@ -546,17 +546,17 @@ pub fn from_unix_seconds(unix_ts: Int) -> tempo.Date {
   tempo.date_from_unix_seconds(unix_ts)
 }
 
-/// Returns the UTC unix timestamp of a date, assuming the time on that date 
+/// Returns the UTC unix timestamp of a date, assuming the time on that date
 /// is 00:00:00.
-/// 
+///
 /// ## Examples
-/// 
+///
 /// ```gleam
 /// date.literal("2024-06-12")
 /// |> date.to_unix_seconds
 /// // -> 1_718_150_400
 /// ```
-/// 
+///
 /// I am making this internal because it is created but I am not sure if it
 /// should be part of the public API. I think it is too easy to use incorrectly.
 /// Users should probably use the 'datetime' module's 'from_unix_seconds' function
@@ -567,16 +567,16 @@ pub fn to_unix_seconds(date: tempo.Date) -> Int {
 }
 
 /// Returns the UTC date of a unix timestamp in milliseconds.
-/// 
+///
 /// From https://howardhinnant.github.io/date_algorithms.html#civil_from_days
-/// 
+///
 /// ## Examples
-/// 
+///
 /// ```gleam
 /// date.from_unix_milli(267_840_000)
 /// // -> date.literal("1978-06-28")
 /// ```
-/// 
+///
 /// I am making this internal because it is created but I am not sure if it
 /// should be part of the public API. I think it is too easy to use incorrectly.
 /// Users should probably use the 'datetime' module's 'from_unix_seconds' function
@@ -588,15 +588,15 @@ pub fn from_unix_milli(unix_ts: Int) -> tempo.Date {
 
 /// Returns the UTC unix timestamp in milliseconds of a date, assuming the
 /// time on that date is 00:00:00.
-/// 
+///
 /// ## Examples
-/// 
+///
 /// ```gleam
 /// date.literal("2024-06-12")
 /// |> date.to_unix_milli
 /// // -> 1_718_150_400_000
 /// ```
-/// 
+///
 /// I am making this internal because it is created but I am not sure if it
 /// should be part of the public API. I think it is too easy to use incorrectly.
 /// Users should probably use the 'datetime' module's 'from_unix_seconds' function
@@ -607,16 +607,16 @@ pub fn to_unix_milli(date: tempo.Date) -> Int {
 }
 
 /// Returns the UTC date of a unix timestamp in microseconds.
-/// 
+///
 /// From https://howardhinnant.github.io/date_algorithms.html#civil_from_days
-/// 
+///
 /// ## Examples
-/// 
+///
 /// ```gleam
 /// date.from_unix_milli(267_840_000_000)
 /// // -> date.literal("1978-06-28")
 /// ```
-/// 
+///
 /// I am making this internal because it is created but I am not sure if it
 /// should be part of the public API. I think it is too easy to use incorrectly.
 /// Users should probably use the 'datetime' module's 'from_unix_seconds' function
@@ -628,15 +628,15 @@ pub fn from_unix_micro(unix_ts: Int) -> tempo.Date {
 
 /// Returns the UTC unix timestamp in microseconds of a date, assuming the
 /// time on that date is 00:00:00.
-/// 
+///
 /// ## Examples
-/// 
+///
 /// ```gleam
 /// date.literal("2024-06-12")
 /// |> date.to_unix_micro
 /// // -> 1_718_150_400_000_000
 /// ```
-/// 
+///
 /// I am making this internal because it is created but I am not sure if it
 /// should be part of the public API. I think it is too easy to use incorrectly.
 /// Users should probably use the 'datetime' module's 'from_unix_seconds' function
@@ -646,11 +646,11 @@ pub fn to_unix_micro(date: tempo.Date) -> Int {
   tempo.date_to_unix_micro(date)
 }
 
-/// Creates a date from a Rata Die value. 
+/// Creates a date from a Rata Die value.
 /// Adapted from the very nice Rada Gleam library!
-/// 
+///
 /// ## Example
-/// 
+///
 /// ```gleam
 /// date.from_rata_die(739_050)
 /// // -> date.literal("2024-06-13")
@@ -661,9 +661,9 @@ pub fn from_rata_die(rata_die: Int) -> tempo.Date {
 
 /// Returns the Rata Die value of the date as an Int.
 /// Adapted from the very nice Rada Gleam library!
-/// 
+///
 /// ## Example
-/// 
+///
 /// ```gleam
 /// date.literal("2024-06-13")
 /// |> date.to_rata_die
@@ -674,21 +674,21 @@ pub fn to_rata_die(date: tempo.Date) -> Int {
 }
 
 /// Compares two dates.
-/// 
+///
 /// ## Examples
-/// 
+///
 /// ```gleam
 /// date.literal("2024-06-12")
 /// |> date.compare(to: date.literal("2024-06-12"))
 /// // -> order.Eq
 /// ```
-/// 
+///
 /// ```gleam
 /// date.literal("2024-05-12")
 /// |> date.compare(to: date.literal("2024-06-13"))
 /// // -> order.Lt
 /// ```
-/// 
+///
 /// ```gleam
 /// date.literal("2034-06-12")
 /// |> date.compare(to: date.literal("2024-06-11"))
@@ -707,7 +707,7 @@ pub fn compare(a: tempo.Date, to b: tempo.Date) -> order.Order {
 /// |> date.is_earlier(than: date.literal("2024-06-13"))
 /// // -> True
 /// ```
-/// 
+///
 /// ```gleam
 /// date.literal("2024-06-12")
 /// |> date.is_earlier(than: date.literal("2024-06-12"))
@@ -718,14 +718,14 @@ pub fn is_earlier(a: tempo.Date, than b: tempo.Date) -> Bool {
 }
 
 /// Checks if the first date is earlier than or equal to the second date.
-/// 
+///
 /// ## Examples
 /// ```gleam
 /// date.literal("2024-06-12")
 /// |> date.is_earlier_or_equal(to: date.literal("2024-06-12"))
 /// // -> True
 /// ```
-/// 
+///
 /// ```gleam
 /// date.literal("2024-06-12")
 /// |> date.is_earlier_or_equal(to: date.literal("2024-06-11"))
@@ -738,7 +738,7 @@ pub fn is_earlier_or_equal(a: tempo.Date, to b: tempo.Date) -> Bool {
 /// Checks if two dates are equal.
 ///
 /// ## Example
-/// 
+///
 /// ```gleam
 /// date.literal("2024-06-12")
 /// |> date.is_equal(to: date.literal("2024-06-12"))
@@ -757,7 +757,7 @@ pub fn is_equal(a: tempo.Date, to b: tempo.Date) -> Bool {
 /// |> date.is_later(than: date.literal("2024-06-13"))
 /// // -> True
 /// ```
-/// 
+///
 /// ```gleam
 /// date.literal("2024-06-12")
 /// |> date.is_later(than: date.literal("2024-06-12"))
@@ -768,7 +768,7 @@ pub fn is_later(a: tempo.Date, than b: tempo.Date) -> Bool {
 }
 
 /// Checks if the first date is later than or equal to the second date.
-/// 
+///
 /// ## Examples
 ///
 /// ```gleam
@@ -776,7 +776,7 @@ pub fn is_later(a: tempo.Date, than b: tempo.Date) -> Bool {
 /// |> date.is_later_or_equal(to: date.literal("2024-06-12"))
 /// // -> True
 /// ```
-/// 
+///
 /// ```gleam
 /// date.literal("2024-06-12")
 /// |> date.is_later_or_equal(to: date.literal("2024-06-13"))
@@ -787,15 +787,15 @@ pub fn is_later_or_equal(a: tempo.Date, to b: tempo.Date) -> Bool {
 }
 
 /// Gets the difference between two dates.
-/// 
+///
 /// ## Examples
-/// 
+///
 /// ```gleam
 /// date.literal("2024-06-12")
 /// |> date.difference(from: date.literal("2024-06-23"))
 /// // -> 11
 /// ```
-/// 
+///
 /// ```gleam
 /// date.literal("2024-06-03")
 /// |> date.difference(from: date.literal("2024-06-11"))
@@ -807,16 +807,16 @@ pub fn difference(from a: tempo.Date, to b: tempo.Date) -> Int {
 
 /// Creates a period between the first date at 00:00:00 and the second date at
 /// 24:00:00. Periods only represent positive datetime differences.
-/// 
+///
 /// ## Examples
-/// 
+///
 /// ```gleam
 /// date.literal("2024-06-12")
 /// |> date.as_period(end: date.literal("2024-06-23"))
 /// |> period.as_days
 /// // -> 11
 /// ```
-/// 
+///
 /// ```gleam
 /// date.literal("2024-06-12")
 /// |> date.as_period(start: date.literal("2024-06-09"))
@@ -828,15 +828,15 @@ pub fn as_period(start start: tempo.Date, end end: tempo.Date) -> tempo.Period {
 }
 
 /// Adds a number of days to a date.
-/// 
+///
 /// ## Examples
-/// 
+///
 /// ```gleam
 /// date.literal("2024-06-12")
 /// |> date.add(days: 1)
 /// // -> date.literal("2024-06-13")
 /// ```
-/// 
+///
 /// ```gleam
 /// date.literal("2024-06-12")
 /// |> date.add(days: 12)
@@ -847,15 +847,15 @@ pub fn add(date: tempo.Date, days days: Int) -> tempo.Date {
 }
 
 /// Subtracts a number of days from a date.
-/// 
+///
 /// ## Examples
-/// 
+///
 /// ```gleam
 /// date.literal("2024-06-12")
 /// |> date.subtract(days: 1)
 /// // -> date.literal("2024-06-11")
 /// ```
-/// 
+///
 /// ```gleam
 /// date.literal("2024-06-12")
 /// |> date.subtract(days: 12)
@@ -867,9 +867,9 @@ pub fn subtract(date: tempo.Date, days days: Int) -> tempo.Date {
 
 /// Returns the number of the day of week a date falls on.
 /// Will be incorrect for dates before 1752 and dates after 2300.
-/// 
+///
 /// ## Examples
-/// 
+///
 /// ```gleam
 /// date.literal("2024-06-21")
 /// |> date.to_day_of_week_number
@@ -881,9 +881,9 @@ pub fn to_day_of_week_number(date: tempo.Date) -> Int {
 
 /// Returns the day of week a date falls on.
 /// Will be incorrect for dates before 1752 and dates after 2300.
-/// 
+///
 /// ## Examples
-/// 
+///
 /// ```gleam
 /// date.literal("2024-06-20")
 /// |> date.to_day_of_week
@@ -903,9 +903,9 @@ pub fn to_day_of_week(date: tempo.Date) -> DayOfWeek {
 }
 
 /// Returns the short string representation of a day of the week.
-/// 
+///
 /// ## Examples
-/// 
+///
 /// ```gleam
 /// date|> tempo.date_get_day_of_week_to_short_string(date.Mon)
 /// // -> "Mon"
@@ -923,9 +923,9 @@ pub fn day_of_week_to_short_string(day_of_week: DayOfWeek) -> String {
 }
 
 /// Returns the long string representation of a day of the week.
-/// 
+///
 /// ## Examples
-/// 
+///
 /// ```gleam
 /// date|> tempo.date_get_day_of_week_to_long_string(date.Fri)
 /// // -> "Friday"
@@ -944,15 +944,15 @@ pub fn day_of_week_to_long_string(day_of_week: DayOfWeek) -> String {
 
 /// Gets the date of the next specified day of the week, exclusive of
 /// the passed date.
-/// 
+///
 /// ## Examples
-/// 
+///
 /// ```gleam
 /// date.literal("2024-06-21")
 /// |> date.next_day_of_week(date.Mon)
 /// // -> date.literal("2024-06-24")
 /// ```
-/// 
+///
 /// ```gleam
 /// date.literal("2024-06-21")
 /// |> date.next_day_of_week(date.Fri)
@@ -972,15 +972,15 @@ pub fn next_day_of_week(
 
 /// Gets the date of the prior specified day of the week, exclusive of
 /// the passed date.
-/// 
+///
 /// ## Examples
-/// 
+///
 /// ```gleam
 /// date.literal("2024-06-21")
 /// |> date.prior_day_of_week(date.Mon)
 /// // -> date.literal("2024-06-17")
 /// ```
-/// 
+///
 /// ```gleam
 /// date.literal("2024-06-21")
 /// |> date.prior_day_of_week(date.Fri)
@@ -999,9 +999,9 @@ pub fn prior_day_of_week(
 }
 
 /// Checks if a date falls in a weekend.
-/// 
+///
 /// ## Examples
-/// 
+///
 /// ```gleam
 /// date.literal("2024-06-22")
 /// |> date.is_weekend
@@ -1015,9 +1015,9 @@ pub fn is_weekend(date: tempo.Date) -> Bool {
 }
 
 /// Gets the first date of the month a date occurs in.
-/// 
+///
 /// ## Examples
-/// 
+///
 /// ```gleam
 /// date.literal("2024-06-21")
 /// |> date.first_of_month
@@ -1030,9 +1030,9 @@ pub fn first_of_month(for date: tempo.Date) -> tempo.Date {
 }
 
 /// Gets the last date of the month a date occurs in.
-/// 
+///
 /// ## Examples
-/// 
+///
 /// ```gleam
 /// date.literal("2024-02-13")
 /// |> date.last_of_month

--- a/src/tempo/datetime.gleam
+++ b/src/tempo/datetime.gleam
@@ -438,13 +438,13 @@ pub fn to_unix_micro(datetime: tempo.DateTime) -> Int {
 /// ## Examples
 ///
 /// ```gleam
-/// dynamic.from("2024-06-13T13:42:11.195Z")
+/// dynamic.string("2024-06-13T13:42:11.195Z")
 /// |> datetime.from_dynamic_string
 /// // -> Ok(datetime.literal("2024-06-13T13:42:11.195Z"))
 /// ```
 ///
 /// ```gleam
-/// dynamic.from("24-06-13,13:42:11.195")
+/// dynamic.string("24-06-13,13:42:11.195")
 /// |> datetime.from_dynamic_string
 /// // -> Error([
 /// //   decode.DecodeError(
@@ -492,13 +492,13 @@ pub fn from_dynamic_string(
 /// ## Examples
 ///
 /// ```gleam
-/// dynamic.from(1_718_629_314)
+/// dynamic.int(1_718_629_314)
 /// |> datetime.from_dynamic_unix_utc
 /// // -> Ok(datetime.literal("2024-06-17T13:01:54Z"))
 /// ```
 ///
 /// ```gleam
-/// dynamic.from("hello")
+/// dynamic.string("hello")
 /// |> datetime.from_dynamic_unix_utc
 /// // -> Error([
 /// //   decode.DecodeError(
@@ -531,13 +531,13 @@ pub fn from_dynamic_unix_utc(
 /// ## Examples
 ///
 /// ```gleam
-/// dynamic.from(1_718_629_314_334)
+/// dynamic.int(1_718_629_314_334)
 /// |> datetime.from_dynamic_unix_milli_utc
 /// // -> Ok(datetime.literal("2024-06-17T13:01:54.334Z"))
 /// ```
 ///
 /// ```gleam
-/// dynamic.from("hello")
+/// dynamic.string("hello")
 /// |> datetime.from_dynamic_unix_milli_utc
 /// // -> Error([
 /// //   decode.DecodeError(
@@ -570,13 +570,13 @@ pub fn from_dynamic_unix_milli_utc(
 /// ## Examples
 ///
 /// ```gleam
-/// dynamic.from(1_718_629_314_334_734)
+/// dynamic.int(1_718_629_314_334_734)
 /// |> datetime.from_dynamic_unix_micro_utc
 /// // -> Ok(datetime.literal("2024-06-17T13:01:54.334734Z"))
 /// ```
 ///
 /// ```gleam
-/// dynamic.from("hello")
+/// dynamic.string("hello")
 /// |> datetime.from_dynamic_unix_micro_utc
 /// // -> Error([
 /// //   decode.DecodeError(

--- a/src/tempo/datetime.gleam
+++ b/src/tempo/datetime.gleam
@@ -49,6 +49,9 @@ import tempo/naive_datetime
 import tempo/offset
 import tempo/time
 
+/// Starting point of unix timestamps
+pub const unix_epoch = tempo.unix_epoch
+
 /// Create a new datetime from a date, time, and offset.
 ///
 /// ## Examples

--- a/src/tempo/datetime.gleam
+++ b/src/tempo/datetime.gleam
@@ -1,32 +1,32 @@
 //// Functions to use with the `DateTime` type in Tempo.
-//// 
+////
 //// ## Examples
-//// 
+////
 //// ```gleam
 //// import tempo/datetime
 //// import snag
-//// 
+////
 //// pub fn main() {
 ////   datetime.literal("2024-12-25T06:00:00+05:00")
 ////   |> datetime.format("ddd @ h:mm A, Z")
 ////   // -> "Fri @ 6:00 AM, +05:00"
-//// 
+////
 ////   datetime.parse("06:21:2024 23:17:07.123Z", "MM:DD:YYYY HH:mm:ss.SSSZ")
 ////   |> snag.map_error(datetime.describe_parse_error)
 ////   |> result.map(datetime.to_string)
 ////   // -> Ok("2024-06-21T23:17:07.123Z")
 //// }
 //// ```
-//// 
+////
 //// ```gleam
 //// import gleam/list
 //// import tempo/datetime
 //// import tempo/period
-//// 
+////
 //// pub fn get_every_friday_between(datetime1, datetime2) {
 ////   period.new(datetime1, datetime2)
 ////   |> period.comprising_dates
-////   |> list.filter(fn(date) { 
+////   |> list.filter(fn(date) {
 ////     date |> date.to_day_of_week == date.Fri
 ////   })
 ////   // -> ["2024-06-21", "2024-06-28", "2024-07-05"]
@@ -50,12 +50,12 @@ import tempo/offset
 import tempo/time
 
 /// Create a new datetime from a date, time, and offset.
-/// 
+///
 /// ## Examples
-/// 
+///
 /// ```gleam
 /// datetime.new(
-///   date.literal("2024-06-13"), 
+///   date.literal("2024-06-13"),
 ///   time.literal("23:04:00.009"),
 ///   offset.literal("+10:00"),
 /// )
@@ -72,12 +72,12 @@ pub fn new(
 /// Create a new datetime value from a string literal, but will panic if
 /// the string is invalid. Accepted formats are `YYYY-MM-DDThh:mm:ss.sTZD` or
 /// `YYYYMMDDThhmmss.sTZD`
-/// 
-/// Useful for declaring datetime literals that you know are valid within your  
+///
+/// Useful for declaring datetime literals that you know are valid within your
 /// program.
 ///
 /// ## Examples
-/// 
+///
 /// ```gleam
 /// datetime.literal("2024-06-13T23:04:00.009+10:00")
 /// |> datetime.to_string
@@ -98,12 +98,12 @@ pub fn literal(datetime: String) -> tempo.DateTime {
 
 /// Parses a datetime string in the format `YYYY-MM-DDThh:mm:ss.sTZD`,
 /// `YYYYMMDDThhmmss.sTZD`, `YYYY-MM-DD hh:mm:ss.sTZD`,
-/// `YYYYMMDD hhmmss.sTZD`, `YYYY-MM-DD`, `YYYY-M-D`, `YYYY/MM/DD`, 
-/// `YYYY/M/D`, `YYYY.MM.DD`, `YYYY.M.D`, `YYYY_MM_DD`, `YYYY_M_D`, 
+/// `YYYYMMDD hhmmss.sTZD`, `YYYY-MM-DD`, `YYYY-M-D`, `YYYY/MM/DD`,
+/// `YYYY/M/D`, `YYYY.MM.DD`, `YYYY.M.D`, `YYYY_MM_DD`, `YYYY_M_D`,
 /// `YYYY MM DD`, `YYYY M D`, or `YYYYMMDD`.
-/// 
+///
 /// ## Examples
-/// 
+///
 /// ```gleam
 /// datetime.from_string("20240613T230400.009+00:00")
 /// // -> datetime.literal("2024-06-13T23:04:00.009Z")
@@ -168,15 +168,15 @@ fn split_time_and_offset(time_with_offset: String) {
 }
 
 /// Returns a string representation of a datetime value in the ISO 8601
-/// format with millisecond precision. If a different precision is needed, 
+/// format with millisecond precision. If a different precision is needed,
 /// use the `format` function. If serializing to send outside of Gleam and then
 /// parse back into a datetime value, use the `serialize` function.
-/// 
+///
 /// ## Examples
-/// 
+///
 /// ```gleam
 /// datetime.to_string(my_datetime)
-/// // -> "2024-06-21T05:22:22.009534Z" 
+/// // -> "2024-06-21T05:22:22.009534Z"
 /// ```
 pub fn to_string(datetime: tempo.DateTime) -> String {
   tempo.datetime_to_string(datetime)
@@ -186,31 +186,31 @@ pub fn to_string(datetime: tempo.DateTime) -> String {
 /// this over `parse_any`. All parsed formats must have all parts of a
 /// datetime (date, time, offset). Use the other modules for parsing lesser
 /// date time values.
-/// 
+///
 /// Values can be escaped by putting brackets around them, like "[Hello!] YYYY".
-/// 
-/// Available directives: YY (two-digit year), YYYY (four-digit year), M (month), 
-/// MM (two-digit month), MMM (short month name), MMMM (full month name), 
+///
+/// Available directives: YY (two-digit year), YYYY (four-digit year), M (month),
+/// MM (two-digit month), MMM (short month name), MMMM (full month name),
 /// D (day of the month), DD (two-digit day of the month),
-/// H (hour), HH (two-digit hour), h (12-hour clock hour), hh 
+/// H (hour), HH (two-digit hour), h (12-hour clock hour), hh
 /// (two-digit 12-hour clock hour), m (minute), mm (two-digit minute),
-/// s (second), ss (two-digit second), SSS (millisecond), SSSS (microsecond), 
+/// s (second), ss (two-digit second), SSS (millisecond), SSSS (microsecond),
 /// Z (offset from UTC), ZZ (offset from UTC with no ":"),
-/// z (short offset from UTC "-04", "Z"), zz (full offset from UTC as "-04:00" 
+/// z (short offset from UTC "-04", "Z"), zz (full offset from UTC as "-04:00"
 /// or "Z" if UTC), A (AM/PM), a (am/pm).
-/// 
+///
 /// ## Example
-/// 
+///
 /// ```gleam
 /// datetime.parse("2024/06/08, 13:42:11, -04:00", "YYYY/MM/DD, HH:mm:ss, Z")
 /// // -> Ok(datetime.literal("2024-06-08T13:42:11-04"))
 /// ```
-/// 
+///
 /// ```gleam
 /// datetime.parse("January 13, 2024. 3:42:11Z", "MMMM DD, YYYY. H:mm:ssz")
 /// // -> Ok(datetime.literal("2024-01-13T03:42:11Z"))
 /// ```
-/// 
+///
 /// ```gleam
 /// datetime.parse("Hi! 2024 11 13 12 2 am Z", "[Hi!] YYYY M D h m a z")
 /// // -> Ok(datetime.literal("2024-11-13T00:02:00Z"))
@@ -223,7 +223,7 @@ pub fn parse(
 
   use #(parts, _) <- result.try(
     tempo.consume_format(str, in: format_str)
-    |> result.map_error(tempo_error.DateTimeInvalidFormat(_)),
+    |> result.map_error(tempo_error.DateTimeInvalidFormat),
   )
 
   use date <- result.try(
@@ -244,17 +244,17 @@ pub fn parse(
   Ok(new(date, time, offset))
 }
 
-/// Tries to parse a given date string without a known format. It will not 
-/// parse two digit years and will assume the month always comes before the 
+/// Tries to parse a given date string without a known format. It will not
+/// parse two digit years and will assume the month always comes before the
 /// day in a date.
-/// 
+///
 /// ## Example
-/// 
+///
 /// ```gleam
 /// parse_any.parse_any("2024.06.21 01:32 PM -0400")
 /// // -> Ok(datetime.literal("2024-06-21T13:32:00-04:00"))
 /// ```
-/// 
+///
 /// ```gleam
 /// parse_any.parse_any("2024.06.21 01:32 PM")
 /// // -> Error(tempo.ParseMissingOffset)
@@ -276,9 +276,9 @@ pub fn parse_any(
 }
 
 /// Converts a datetime parse error to a human readable error message.
-/// 
+///
 /// ## Example
-/// 
+///
 /// ```gleam
 /// datetime.parse("13:42:11.314-04:00", "YYYY-MM-DDTHH:mm:ss.SSSZ")
 /// |> snag.map_error(with: datetime.describe_parse_error)
@@ -288,27 +288,27 @@ pub fn describe_parse_error(error: tempo_error.DateTimeParseError) {
 }
 
 /// Formats a datetime value into a string using the provided format.
-/// 
+///
 /// ## Examples
-/// 
+///
 /// ```gleam
 /// datetime.literal(tempo.Custom("2024-06-21T13:42:11.314-04:00"))
 /// |> datetime.format("ddd @ h:mm A (z)")
 /// // -> "Fri @ 1:42 PM (-04)"
 /// ```
-/// 
+///
 /// ```gleam
 /// datetime.literal("2024-06-03T09:02:01-04:00")
 /// |> datetime.format(tempo.Custom("YY YYYY M MM MMM MMMM D DD d dd ddd"))
 /// // -----------:---------------> "24 2024 6 06 Jun June 3 03 1 Mo Mon"
 /// ```
-/// 
-/// ```gleam 
+///
+/// ```gleam
 /// datetime.literal("2024-06-03T09:02:01.014920202-00:00")
 /// |> datetime.format(tempo.Custom("dddd SSS SSSS SSSSS Z ZZ z"))
 /// // -> "Monday 014 014920 014920202 -00:00 -0000 Z"
 /// ```
-/// 
+///
 /// ```gleam
 /// datetime.literal("2024-06-03T13:02:01-04:00")
 /// |> datetime.format(tempo.Custom("H HH h hh m mm s ss a A [An ant]"))
@@ -343,9 +343,9 @@ pub fn to_timestamp(datetime: tempo.DateTime) -> timestamp.Timestamp {
 }
 
 /// Returns the UTC datetime of a unix timestamp.
-/// 
+///
 /// ## Examples
-/// 
+///
 /// ```gleam
 /// datetime.from_unix_seconds(1_718_829_191)
 /// // -> datetime.literal("2024-06-17T12:59:51Z")
@@ -359,9 +359,9 @@ pub fn from_unix_seconds(unix_ts: Int) -> tempo.DateTime {
 }
 
 /// Returns the UTC unix timestamp of a datetime.
-/// 
+///
 /// ## Examples
-/// 
+///
 /// ```gleam
 /// datetime.literal("2024-06-17T12:59:51Z")
 /// |> datetime.to_unix_seconds
@@ -378,9 +378,9 @@ pub fn to_unix_seconds(datetime: tempo.DateTime) -> Int {
 }
 
 /// Returns the UTC datetime of a unix timestamp in milliseconds.
-/// 
+///
 /// ## Examples
-/// 
+///
 /// ```gleam
 /// datetime.from_unix_milli(1_718_629_314_334)
 /// // -> datetime.literal("2024-06-17T13:01:54.334Z")
@@ -390,9 +390,9 @@ pub fn from_unix_milli(unix_ts: Int) -> tempo.DateTime {
 }
 
 /// Returns the UTC unix timestamp in milliseconds of a datetime.
-/// 
+///
 /// ## Examples
-/// 
+///
 /// ```gleam
 /// datetime.literal("2024-06-17T13:01:54.334Z")
 /// |> datetime.to_unix_milli
@@ -408,9 +408,9 @@ pub fn to_unix_milli(datetime: tempo.DateTime) -> Int {
 }
 
 /// Returns the UTC datetime of a unix timestamp in microseconds.
-/// 
+///
 /// ## Examples
-/// 
+///
 /// ```gleam
 /// datetime.from_unix_micro(1_718_629_314_334_734)
 /// // -> datetime.literal("2024-06-17T13:01:54.334734Z")
@@ -420,9 +420,9 @@ pub fn from_unix_micro(unix_ts: Int) -> tempo.DateTime {
 }
 
 /// Returns the UTC unix timestamp in microseconds of a datetime.
-/// 
+///
 /// ## Examples
-/// 
+///
 /// ```gleam
 /// datetime.literal("2024-06-17T13:01:54.334734Z")
 /// |> datetime.to_unix_micro
@@ -434,20 +434,20 @@ pub fn to_unix_micro(datetime: tempo.DateTime) -> Int {
 
 /// Checks if a dynamic value is a valid datetime string, and returns the
 /// datetime if it is.
-/// 
+///
 /// ## Examples
-/// 
+///
 /// ```gleam
 /// dynamic.from("2024-06-13T13:42:11.195Z")
 /// |> datetime.from_dynamic_string
 /// // -> Ok(datetime.literal("2024-06-13T13:42:11.195Z"))
 /// ```
-/// 
+///
 /// ```gleam
 /// dynamic.from("24-06-13,13:42:11.195")
 /// |> datetime.from_dynamic_string
 /// // -> Error([
-/// //   dynamic.DecodeError(
+/// //   decode.DecodeError(
 /// //     expected: "tempo.DateTime",
 /// //     found: "Invalid format: 24-06-13,13:42:11.195",
 /// //     path: [],
@@ -456,14 +456,14 @@ pub fn to_unix_micro(datetime: tempo.DateTime) -> Int {
 /// ```
 pub fn from_dynamic_string(
   dynamic_string: dynamic.Dynamic,
-) -> Result(tempo.DateTime, List(dynamic.DecodeError)) {
+) -> Result(tempo.DateTime, List(decode.DecodeError)) {
   use datetime: String <- result.try(
-    // Uses the decode.string function but maintains the dynamic.DecodeError
+    // Uses the decode.string function but maintains the decode.DecodeError
     // return type to maintain API compatibility.
     decode.run(dynamic_string, decode.string)
     |> result.map_error(fn(errs) {
       list.map(errs, fn(err) {
-        dynamic.DecodeError(err.expected, err.found, err.path)
+        decode.DecodeError(err.expected, err.found, err.path)
       })
     }),
   )
@@ -472,7 +472,7 @@ pub fn from_dynamic_string(
     Ok(datetime) -> Ok(datetime)
     Error(tempo_error) ->
       Error([
-        dynamic.DecodeError(
+        decode.DecodeError(
           expected: "tempo.DateTime",
           found: case tempo_error {
             tempo_error.DateTimeInvalidFormat(msg) -> msg
@@ -486,22 +486,22 @@ pub fn from_dynamic_string(
   }
 }
 
-/// Checks if a dynamic value is a valid unix timestamp in seconds, and 
+/// Checks if a dynamic value is a valid unix timestamp in seconds, and
 /// returns the datetime representation if it is.
-/// 
+///
 /// ## Examples
-/// 
+///
 /// ```gleam
 /// dynamic.from(1_718_629_314)
 /// |> datetime.from_dynamic_unix_utc
 /// // -> Ok(datetime.literal("2024-06-17T13:01:54Z"))
 /// ```
-/// 
+///
 /// ```gleam
 /// dynamic.from("hello")
 /// |> datetime.from_dynamic_unix_utc
 /// // -> Error([
-/// //   dynamic.DecodeError(
+/// //   decode.DecodeError(
 /// //     expected: "Int",
 /// //     found: "String",
 /// //     path: [],
@@ -510,14 +510,14 @@ pub fn from_dynamic_string(
 /// ```
 pub fn from_dynamic_unix_utc(
   dynamic_ts: dynamic.Dynamic,
-) -> Result(tempo.DateTime, List(dynamic.DecodeError)) {
+) -> Result(tempo.DateTime, List(decode.DecodeError)) {
   use unix_seconds: Int <- result.map(
-    // Uses the decode.int function but maintains the dynamic.DecodeError
+    // Uses the decode.int function but maintains the decode.DecodeError
     // return type to maintain API compatibility.
     decode.run(dynamic_ts, decode.int)
     |> result.map_error(fn(errs) {
       list.map(errs, fn(err) {
-        dynamic.DecodeError(err.expected, err.found, err.path)
+        decode.DecodeError(err.expected, err.found, err.path)
       })
     }),
   )
@@ -525,22 +525,22 @@ pub fn from_dynamic_unix_utc(
   from_unix_seconds(unix_seconds)
 }
 
-/// Checks if a dynamic value is a valid unix timestamp in milliseconds, and 
+/// Checks if a dynamic value is a valid unix timestamp in milliseconds, and
 /// returns the datetime if it is.
-/// 
+///
 /// ## Examples
-/// 
+///
 /// ```gleam
 /// dynamic.from(1_718_629_314_334)
 /// |> datetime.from_dynamic_unix_milli_utc
 /// // -> Ok(datetime.literal("2024-06-17T13:01:54.334Z"))
 /// ```
-/// 
+///
 /// ```gleam
 /// dynamic.from("hello")
 /// |> datetime.from_dynamic_unix_milli_utc
 /// // -> Error([
-/// //   dynamic.DecodeError(
+/// //   decode.DecodeError(
 /// //     expected: "Int",
 /// //     found: "String",
 /// //     path: [],
@@ -549,14 +549,14 @@ pub fn from_dynamic_unix_utc(
 /// ```
 pub fn from_dynamic_unix_milli_utc(
   dynamic_ts: dynamic.Dynamic,
-) -> Result(tempo.DateTime, List(dynamic.DecodeError)) {
+) -> Result(tempo.DateTime, List(decode.DecodeError)) {
   use unix_milli: Int <- result.map(
-    // Uses the decode.int function but maintains the dynamic.DecodeError
+    // Uses the decode.int function but maintains the decode.DecodeError
     // return type to maintain API compatibility.
     decode.run(dynamic_ts, decode.int)
     |> result.map_error(fn(errs) {
       list.map(errs, fn(err) {
-        dynamic.DecodeError(err.expected, err.found, err.path)
+        decode.DecodeError(err.expected, err.found, err.path)
       })
     }),
   )
@@ -564,22 +564,22 @@ pub fn from_dynamic_unix_milli_utc(
   from_unix_milli(unix_milli)
 }
 
-/// Checks if a dynamic value is a valid unix timestamp in microseconds, and 
+/// Checks if a dynamic value is a valid unix timestamp in microseconds, and
 /// returns the datetime if it is.
-/// 
+///
 /// ## Examples
-/// 
+///
 /// ```gleam
 /// dynamic.from(1_718_629_314_334_734)
 /// |> datetime.from_dynamic_unix_micro_utc
 /// // -> Ok(datetime.literal("2024-06-17T13:01:54.334734Z"))
 /// ```
-/// 
+///
 /// ```gleam
 /// dynamic.from("hello")
 /// |> datetime.from_dynamic_unix_micro_utc
 /// // -> Error([
-/// //   dynamic.DecodeError(
+/// //   decode.DecodeError(
 /// //     expected: "Int",
 /// //     found: "String",
 /// //     path: [],
@@ -588,14 +588,14 @@ pub fn from_dynamic_unix_milli_utc(
 /// ```
 pub fn from_dynamic_unix_micro_utc(
   dynamic_ts: dynamic.Dynamic,
-) -> Result(tempo.DateTime, List(dynamic.DecodeError)) {
+) -> Result(tempo.DateTime, List(decode.DecodeError)) {
   use unix_micro: Int <- result.map(
-    // Uses the decode.int function but maintains the dynamic.DecodeError
+    // Uses the decode.int function but maintains the decode.DecodeError
     // return type to maintain API compatibility.
     decode.run(dynamic_ts, decode.int)
     |> result.map_error(fn(errs) {
       list.map(errs, fn(err) {
-        dynamic.DecodeError(err.expected, err.found, err.path)
+        decode.DecodeError(err.expected, err.found, err.path)
       })
     }),
   )
@@ -604,9 +604,9 @@ pub fn from_dynamic_unix_micro_utc(
 }
 
 /// Gets the date of a datetime.
-/// 
+///
 /// ## Examples
-/// 
+///
 /// ```gleam
 /// datetime.literal("2024-06-21T13:42:11.195Z")
 /// |> datetime.get_date
@@ -617,9 +617,9 @@ pub fn get_date(datetime: tempo.DateTime) -> tempo.Date {
 }
 
 /// Gets the core gleam time package calendar date of a datetime.
-/// 
+///
 /// ## Examples
-/// 
+///
 /// ```gleam
 /// datetime.literal("2024-06-21T13:42:11.195Z")
 /// |> datetime.get_calendar_date
@@ -630,9 +630,9 @@ pub fn get_calendar_date(datetime: tempo.DateTime) -> calendar.Date {
 }
 
 /// Gets the time of a datetime.
-/// 
+///
 /// ## Examples
-/// 
+///
 /// ```gleam
 /// datetime.literal("2024-06-21T13:42:11.195Z")
 /// |> datetime.get_time
@@ -643,9 +643,9 @@ pub fn get_time(datetime: tempo.DateTime) -> tempo.Time {
 }
 
 /// Gets the core gleam time package calendar time of day of a datetime.
-/// 
+///
 /// ## Examples
-/// 
+///
 /// ```gleam
 /// datetime.literal("2024-06-21T13:42:11.195Z")
 /// |> datetime.get_calendar_time_of_day
@@ -656,9 +656,9 @@ pub fn get_calendar_time_of_day(datetime: tempo.DateTime) -> calendar.TimeOfDay 
 }
 
 /// Gets the offset of a datetime.
-/// 
+///
 /// ## Examples
-/// 
+///
 /// ```gleam
 /// datetime.literal("2024-06-12T13:42:11.195-04:00")
 /// |> datetime.get_offset
@@ -669,9 +669,9 @@ pub fn get_offset(datetime: tempo.DateTime) -> tempo.Offset {
 }
 
 /// Drops the time of a datetime, leaving the date and time values unchanged.
-/// 
+///
 /// ## Examples
-/// 
+///
 /// ```gleam
 /// datetime.literal("2024-06-13T13:42:11.195Z")
 /// |> datetime.drop_offset
@@ -682,9 +682,9 @@ pub fn drop_offset(datetime: tempo.DateTime) -> tempo.NaiveDateTime {
 }
 
 /// Drops the time of a datetime, leaving the date value unchanged.
-/// 
+///
 /// ## Examples
-/// 
+///
 /// ```gleam
 /// datetime.literal("2024-06-18T13:42:11.195Z")
 /// |> datetime.drop_time
@@ -700,11 +700,11 @@ pub fn drop_time(datetime: tempo.DateTime) -> tempo.DateTime {
 }
 
 /// Applies the offset of a datetime to the date and time values, resulting
-/// in a new naive datetime value that represents the original datetime in 
+/// in a new naive datetime value that represents the original datetime in
 /// UTC time.
-/// 
+///
 /// ## Examples
-/// 
+///
 /// ```gleam
 /// datetime.literal("2024-06-21T05:36:11.195-04:00")
 /// |> datetime.apply_offset
@@ -715,9 +715,9 @@ pub fn apply_offset(datetime: tempo.DateTime) -> tempo.NaiveDateTime {
 }
 
 /// Converts a datetime to the equivalent UTC time.
-/// 
+///
 /// ## Examples
-/// 
+///
 /// ```gleam
 /// datetime.literal("2024-06-21T05:36:11.195-04:00")
 /// |> datetime.to_utc
@@ -728,9 +728,9 @@ pub fn to_utc(datetime: tempo.DateTime) -> tempo.DateTime {
 }
 
 /// Converts a datetime to the equivalent time in an offset.
-/// 
+///
 /// ## Examples
-/// 
+///
 /// ```gleam
 /// datetime.literal("2024-06-21T05:36:11.195-04:00")
 /// |> datetime.to_offset(offset.literal("+10:00"))
@@ -746,27 +746,27 @@ pub fn to_offset(
 /// Converts a datetime to the equivalent local datetime. Prefer to either
 /// design your application to not need this, or add an external timezone
 /// provider to use with the `to_timezone` function.
-/// 
-/// Conversion is based on the host's current offset. We can not be 
+///
+/// Conversion is based on the host's current offset. We can not be
 /// sure the current host offset is applicable to the given datetime, and so
 /// an imprecise conversion will be performed. The imprecise conversion can be
-/// inaccurate to the degree the local offset changes throughout the year. 
+/// inaccurate to the degree the local offset changes throughout the year.
 /// For example, in North America where Daylight Savings Time is observed with
 /// a one-hour time shift, the imprecise conversion can be off by up to an hour,
-/// depending on the time of year. 
-/// 
+/// depending on the time of year.
+///
 /// If the date of the given datetime matches the date of the host, then the
 /// conversion will actually be precise all but during the hour(s) when the
-/// time zone offset is shifting. 
-/// 
+/// time zone offset is shifting.
+///
 /// ## Examples
-/// 
+///
 /// ```gleam
 /// datetime.literal("2024-06-21T09:57:11.195Z")
 /// |> datetime.to_local_imprecise
 /// // -> tempo.Precise(datetime.literal("2024-06-21T05:57:11.195-04:00"))
 /// ```
-/// 
+///
 /// ```gleam
 /// datetime.literal("1998-08-23T09:57:11.195Z")
 /// |> datetime.to_local_imprecise
@@ -779,34 +779,34 @@ pub fn to_local_imprecise(datetime: tempo.DateTime) -> tempo.DateTime {
 /// Converts a datetime to the equivalent local time. Prefer to either
 /// design your application to not need this, or add an external timezone
 /// provider to use with the `to_timezone` function.
-/// 
-/// Conversion is based on the host's current offset. We can not be 
+///
+/// Conversion is based on the host's current offset. We can not be
 /// sure the current host offset is applicable to the given datetime, and so
 /// an imprecise conversion will be performed. The imprecise conversion can be
-/// inaccurate to the degree the local offset changes throughout the year. 
+/// inaccurate to the degree the local offset changes throughout the year.
 /// For example, in North America where Daylight Savings Time is observed with
 /// a one-hour time shift, the imprecise conversion can be off by up to an hour,
-/// depending on the time of year. 
-/// 
+/// depending on the time of year.
+///
 /// If the date of the given datetime matches the date of the host, then the
 /// conversion will actually be precise all but during the hour(s) when the
-/// time zone offset is shifting. 
-/// 
+/// time zone offset is shifting.
+///
 /// ## Examples
-/// 
+///
 /// ```gleam
 /// datetime.literal("2024-06-21T09:57:11.195Z")
 /// |> datetime.to_local_time_imprecise
 /// // -> time.literal("05:57:11.195")
 /// ```
-/// 
+///
 /// ```gleam
 /// datetime.literal("1998-08-23T09:57:11.195Z")
 /// |> datetime.to_local_time_imprecise
 /// // -> time.literal("05:57:11.195")
 /// ```
-/// 
-/// Making internal because users can now just call 
+///
+/// Making internal because users can now just call
 /// `datetime.to_local_imprecise(dt).time`. It was harder in prior versions
 @internal
 pub fn to_local_time_imprecise(datetime: tempo.DateTime) -> tempo.Time {
@@ -816,45 +816,45 @@ pub fn to_local_time_imprecise(datetime: tempo.DateTime) -> tempo.Time {
 /// Converts a datetime to the equivalent local time imprecisely. Prefer to either
 /// design your application to not need this, or add an external timezone
 /// provider to use with the `to_timezone` function.
-/// 
-/// Conversion is based on the host's current offset. We can not be 
+///
+/// Conversion is based on the host's current offset. We can not be
 /// sure the current host offset is applicable to the given datetime, and so
 /// an imprecise conversion will be performed. The imprecise conversion can be
-/// inaccurate to the degree the local offset changes throughout the year. 
+/// inaccurate to the degree the local offset changes throughout the year.
 /// For example, in North America where Daylight Savings Time is observed with
 /// a one-hour time shift, the imprecise conversion can be off by up to an hour,
-/// depending on the time of year. 
-/// 
+/// depending on the time of year.
+///
 /// If the date of the given datetime matches the date of the host, then the
 /// conversion will actually be precise all but during the hour(s) when the
 /// time zone offset is shifting.
-/// 
+///
 /// ## Examples
-/// 
+///
 /// ```gleam
 /// datetime.literal("2024-06-19T01:35:11.195Z")
 /// |> datetime.to_local_date_imprecise
 /// // -> date.literal("2024-06-18")
 /// ```
-/// 
+///
 /// ```gleam
 /// datetime.literal("1998-08-23T01:57:11.195Z")
 /// |> datetime.to_local_date_imprecise
 /// // -> date.literal("1998-08-22")
 /// ```
-/// 
-/// Making internal because users can now just call 
+///
+/// Making internal because users can now just call
 /// `datetime.to_local_imprecise(dt).date`. It was harder in prior versions
 @internal
 pub fn to_local_date_imprecise(datetime: tempo.DateTime) -> tempo.Date {
   to_local_imprecise(datetime).date
 }
 
-/// Converts a datetime to the specified timezone. Relies on an external 
+/// Converts a datetime to the specified timezone. Relies on an external
 /// package like `gtz` to provide timezone information.
-/// 
+///
 /// ## Example
-/// 
+///
 /// ```gleam
 /// import gtz
 /// let assert Ok(tz) = gtz.timezone("America/New_York")
@@ -863,7 +863,7 @@ pub fn to_local_date_imprecise(datetime: tempo.DateTime) -> tempo.Date {
 /// |> datetime.to_string
 /// // -> "2024-01-03T02:30:02.334-04:00"
 /// ```
-/// 
+///
 /// ```gleam
 /// import gtz
 /// let assert Ok(local_tz) = gtz.local_name() |> gtz.timezone
@@ -880,15 +880,15 @@ pub fn to_timezone(
 }
 
 /// Gets the name of the timezone the datetime is in.
-/// 
+///
 /// ## Example
-/// 
+///
 /// ```gleam
 /// datetime.literal("2024-06-21T06:30:02.334Z")
 /// |> datetime.get_timezone_name
 /// // -> None
 /// ```
-/// 
+///
 /// ```gleam
 /// import gtz
 /// let assert Ok(tz) = gtz.timezone("Europe/London")
@@ -901,21 +901,21 @@ pub fn get_timezone_name(datetime: tempo.DateTime) -> option.Option(String) {
 }
 
 /// Compares two datetimes.
-/// 
+///
 /// ## Examples
-/// 
+///
 /// ```gleam
 /// datetime.literal("2024-06-21T23:47:00+09:05")
 /// |> datetime.compare(to: datetime.literal("2024-06-21T23:47:00+09:05"))
 /// // -> order.Eq
 /// ```
-/// 
+///
 /// ```gleam
 /// datetime.literal("2023-05-11T13:30:00-04:00")
 /// |> datetime.compare(to: datetime.literal("2023-05-11T13:15:00Z"))
 /// // -> order.Lt
 /// ```
-/// 
+///
 /// ```gleam
 /// datetime.literal("2024-06-12T23:47:00+09:05")
 /// |> datetime.compare(to: datetime.literal("2022-04-12T00:00:00"))
@@ -949,7 +949,7 @@ pub fn is_earlier(a: tempo.DateTime, than b: tempo.DateTime) -> Bool {
 }
 
 /// Checks if the first datetime is earlier or equal to the second datetime.
-/// 
+///
 /// ## Examples
 /// ```gleam
 /// datetime.literal("2024-06-21T23:47:00+09:05")
@@ -958,7 +958,7 @@ pub fn is_earlier(a: tempo.DateTime, than b: tempo.DateTime) -> Bool {
 /// )
 /// // -> True
 /// ```
-/// 
+///
 /// ```gleam
 /// datetime.literal("2024-07-15T23:40:00-04:00")
 /// |> datetime.is_earlier_or_equal(
@@ -971,7 +971,7 @@ pub fn is_earlier_or_equal(a: tempo.DateTime, to b: tempo.DateTime) -> Bool {
 }
 
 /// Checks if the first datetime is equal to the second datetime.
-/// 
+///
 /// ## Examples
 /// ```gleam
 /// datetime.literal("2024-06-21T09:44:00Z")
@@ -980,7 +980,7 @@ pub fn is_earlier_or_equal(a: tempo.DateTime, to b: tempo.DateTime) -> Bool {
 /// )
 /// // -> True
 /// ```
-/// 
+///
 /// ```gleam
 /// datetime.literal("2024-06-21T09:44:00Z")
 /// |> datetime.is_equal(
@@ -1016,7 +1016,7 @@ pub fn is_later(a: tempo.DateTime, than b: tempo.DateTime) -> Bool {
 }
 
 /// Checks if the first datetime is later or equal to the second datetime.
-/// 
+///
 /// ## Examples
 /// ```gleam
 /// datetime.literal("2016-01-11T03:47:00+09:05")
@@ -1025,7 +1025,7 @@ pub fn is_later(a: tempo.DateTime, than b: tempo.DateTime) -> Bool {
 /// )
 /// // -> False
 /// ```
-/// 
+///
 /// ```gleam
 /// datetime.literal("2024-07-15T23:40:00-04:00")
 /// |> datetime.is_later_or_equal(
@@ -1039,9 +1039,9 @@ pub fn is_later_or_equal(a: tempo.DateTime, to b: tempo.DateTime) -> Bool {
 
 /// Returns the difference between two datetimes as a duration between their
 /// equivalent UTC times.
-/// 
+///
 /// ## Examples
-/// 
+///
 /// ```gleam
 /// datetime.literal("2024-06-12T23:17:00Z")
 /// |> datetime.difference(
@@ -1050,7 +1050,7 @@ pub fn is_later_or_equal(a: tempo.DateTime, to b: tempo.DateTime) -> Bool {
 /// |> duration.as_days
 /// // -> 3
 /// ```
-/// 
+///
 /// ```gleam
 /// datetime.literal("2024-06-12T23:17:00Z")
 /// |> datetime.difference(
@@ -1070,12 +1070,12 @@ pub fn difference(
 }
 
 /// Creates a period between two datetimes, where the start and end times are
-/// the equivalent UTC times of the provided datetimes. The specified start 
-/// and end datetimes will be swapped if the start datetime is later than the 
+/// the equivalent UTC times of the provided datetimes. The specified start
+/// and end datetimes will be swapped if the start datetime is later than the
 /// end datetime.
-/// 
+///
 /// ## Examples
-/// 
+///
 /// ```gleam
 /// datetime.to_period(
 ///   start: datetime.literal("2024-06-12T23:17:00Z")
@@ -1084,7 +1084,7 @@ pub fn difference(
 /// |> period.as_days
 /// // -> 3
 /// ```
-/// 
+///
 /// ```gleam
 /// datetime.to_period(
 ///   start: datetime.literal("2024-06-12T23:17:00Z")
@@ -1101,9 +1101,9 @@ pub fn as_period(
 }
 
 /// Adds a duration to a datetime.
-/// 
+///
 /// ## Examples
-/// 
+///
 /// ```gleam
 /// datetime.literal("2024-06-12T23:17:00Z")
 /// |> datetime.add(duration |> tempo.offset_get_minutes(3))
@@ -1117,9 +1117,9 @@ pub fn add(
 }
 
 /// Subtracts a duration from a datetime.
-/// 
+///
 /// ## Examples
-/// 
+///
 /// ```gleam
 /// datetime.literal("2024-06-21T23:17:00Z")
 /// |> datetime.subtract(duration.days(3))
@@ -1133,9 +1133,9 @@ pub fn subtract(
 }
 
 /// Gets the time left in the day.
-/// 
+///
 /// Does **not** account for leap seconds like the rest of the package.
-/// 
+///
 /// ## Examples
 ///
 /// ```gleam
@@ -1143,7 +1143,7 @@ pub fn subtract(
 /// |> naive_datetime.time_left_in_day
 /// // -> time.literal("00:00:57")
 /// ```
-/// 
+///
 /// ```gleam
 /// naive_datetime.literal("2024-06-18T08:05:20-04:00")
 /// |> naive_datetime.time_left_in_day

--- a/test/date_test.gleam
+++ b/test/date_test.gleam
@@ -1,4 +1,5 @@
 import gleam/dynamic
+import gleam/dynamic/decode
 import gleam/order
 import gleam/string
 import gleeunit/should
@@ -491,7 +492,7 @@ pub fn from_dynamic_string_int_test() {
   dynamic.from("153")
   |> date.from_dynamic_string
   |> should.equal(
-    Error([dynamic.DecodeError(expected: "tempo.Date", found: "153", path: [])]),
+    Error([decode.DecodeError(expected: "tempo.Date", found: "153", path: [])]),
   )
 }
 
@@ -500,7 +501,7 @@ pub fn from_dynamic_string_bad_format_test() {
   |> date.from_dynamic_string
   |> should.equal(
     Error([
-      dynamic.DecodeError(expected: "tempo.Date", found: "2024,06,13", path: []),
+      decode.DecodeError(expected: "tempo.Date", found: "2024,06,13", path: []),
     ]),
   )
 }
@@ -510,7 +511,7 @@ pub fn from_dynamic_string_bad_values_test() {
   |> date.from_dynamic_string
   |> should.equal(
     Error([
-      dynamic.DecodeError(expected: "tempo.Date", found: "2024-06-35", path: []),
+      decode.DecodeError(expected: "tempo.Date", found: "2024-06-35", path: []),
     ]),
   )
 }

--- a/test/date_test.gleam
+++ b/test/date_test.gleam
@@ -482,14 +482,14 @@ pub fn to_weekday_test() {
 }
 
 pub fn from_dynamic_string_test() {
-  dynamic.from("2024-06-21")
+  dynamic.string("2024-06-21")
   |> date.from_dynamic_string
   |> should.be_ok
   |> should.equal(date.literal("2024-06-21"))
 }
 
 pub fn from_dynamic_string_int_test() {
-  dynamic.from("153")
+  dynamic.string("153")
   |> date.from_dynamic_string
   |> should.equal(
     Error([decode.DecodeError(expected: "tempo.Date", found: "153", path: [])]),
@@ -497,7 +497,7 @@ pub fn from_dynamic_string_int_test() {
 }
 
 pub fn from_dynamic_string_bad_format_test() {
-  dynamic.from("2024,06,13")
+  dynamic.string("2024,06,13")
   |> date.from_dynamic_string
   |> should.equal(
     Error([
@@ -507,7 +507,7 @@ pub fn from_dynamic_string_bad_format_test() {
 }
 
 pub fn from_dynamic_string_bad_values_test() {
-  dynamic.from("2024-06-35")
+  dynamic.string("2024-06-35")
   |> date.from_dynamic_string
   |> should.equal(
     Error([

--- a/test/datetime_test.gleam
+++ b/test/datetime_test.gleam
@@ -528,14 +528,14 @@ pub fn apply_positive_offset_test() {
 }
 
 pub fn from_dynamic_string_test() {
-  dynamic.from("2024-06-13T13:42:11.195Z")
+  dynamic.string("2024-06-13T13:42:11.195Z")
   |> datetime.from_dynamic_string
   |> should.be_ok
   |> should.equal(datetime.literal("2024-06-13T13:42:11.195Z"))
 }
 
 pub fn from_dynamic_string_int_test() {
-  dynamic.from("153")
+  dynamic.string("153")
   |> datetime.from_dynamic_string
   |> should.equal(
     Error([
@@ -545,7 +545,7 @@ pub fn from_dynamic_string_int_test() {
 }
 
 pub fn from_dynamic_string_bad_format_test() {
-  dynamic.from("24-06-13,13:42:11.195")
+  dynamic.string("24-06-13,13:42:11.195")
   |> datetime.from_dynamic_string
   |> should.equal(
     Error([
@@ -559,7 +559,7 @@ pub fn from_dynamic_string_bad_format_test() {
 }
 
 pub fn from_dynamic_string_bad_values_test() {
-  dynamic.from("2024-06-21T13:99:11.195Z")
+  dynamic.string("2024-06-21T13:99:11.195Z")
   |> datetime.from_dynamic_string
   |> should.equal(
     Error([
@@ -573,40 +573,40 @@ pub fn from_dynamic_string_bad_values_test() {
 }
 
 pub fn from_dynamic_unix_utc_test() {
-  dynamic.from(1_718_629_314)
+  dynamic.int(1_718_629_314)
   |> datetime.from_dynamic_unix_utc
   |> should.be_ok
   |> should.equal(datetime.literal("2024-06-17T13:01:54Z"))
 }
 
 pub fn from_dynamic_unix_utc_error_test() {
-  dynamic.from("hello")
+  dynamic.string("hello")
   |> datetime.from_dynamic_unix_utc
   |> should.be_error
 }
 
 pub fn from_dynamic_unix_milli_utc_test() {
-  dynamic.from(1_718_629_314_334)
+  dynamic.int(1_718_629_314_334)
   |> datetime.from_dynamic_unix_milli_utc
   |> should.be_ok
   |> should.equal(datetime.literal("2024-06-17T13:01:54.334Z"))
 }
 
 pub fn from_dynamic_unix_milli_utc_error_test() {
-  dynamic.from("hello")
+  dynamic.string("hello")
   |> datetime.from_dynamic_unix_milli_utc
   |> should.be_error
 }
 
 pub fn from_dynamic_unix_micro_utc_test() {
-  dynamic.from(1_718_629_314_334_734)
+  dynamic.int(1_718_629_314_334_734)
   |> datetime.from_dynamic_unix_micro_utc
   |> should.be_ok
   |> should.equal(datetime.literal("2024-06-17T13:01:54.334734Z"))
 }
 
 pub fn from_dynamic_unix_micro_utc_error_test() {
-  dynamic.from("hello")
+  dynamic.string("hello")
   |> datetime.from_dynamic_unix_micro_utc
   |> should.be_error
 }
@@ -651,7 +651,7 @@ pub fn to_string_lossless_equality_test() {
 
   dt
   |> datetime.to_string
-  |> dynamic.from
+  |> dynamic.string
   |> datetime.from_dynamic_string
   |> should.equal(Ok(dt))
 }

--- a/test/datetime_test.gleam
+++ b/test/datetime_test.gleam
@@ -1,4 +1,5 @@
 import gleam/dynamic
+import gleam/dynamic/decode
 import gleam/io
 import gleam/order
 import gleam/time/duration as dur
@@ -538,7 +539,7 @@ pub fn from_dynamic_string_int_test() {
   |> datetime.from_dynamic_string
   |> should.equal(
     Error([
-      dynamic.DecodeError(expected: "tempo.DateTime", found: "153", path: []),
+      decode.DecodeError(expected: "tempo.DateTime", found: "153", path: []),
     ]),
   )
 }
@@ -548,7 +549,7 @@ pub fn from_dynamic_string_bad_format_test() {
   |> datetime.from_dynamic_string
   |> should.equal(
     Error([
-      dynamic.DecodeError(
+      decode.DecodeError(
         expected: "tempo.DateTime",
         found: "24-06-13,13:42:11.195",
         path: [],
@@ -562,7 +563,7 @@ pub fn from_dynamic_string_bad_values_test() {
   |> datetime.from_dynamic_string
   |> should.equal(
     Error([
-      dynamic.DecodeError(
+      decode.DecodeError(
         expected: "tempo.DateTime",
         found: "2024-06-21T13:99:11.195Z",
         path: [],


### PR DESCRIPTION
- Some of the types have been moved to `gleam/dynamic/decode`
- Remove use of the deprecated `dynamic#from` call
- Adds `unix_epoch` constant - to easily use it as a default value in structs without having to make a function call

My text editor decided to remove all trailing whitespace chars - I understand this is a personal thing. Let me know if that's okay and if they're there on purpose.