### PR TITLE
Adds #unix_epoch to tempo/date module

### DIFF
--- a/src/tempo.gleam
+++ b/src/tempo.gleam
@@ -917,6 +917,9 @@ pub type DateTime {
 @internal
 pub const unix_epoch = DateTime(Date(0), TimeOfDay(0), utc)
 
+@internal
+pub const unix_epoch_date = Date(0)
+
 /// A type for external packages to provide so that datetimes can be converted
 /// between timezones. The package `gtz` was created to provide this and must
 /// be added as a project dependency separately.

--- a/src/tempo/date.gleam
+++ b/src/tempo/date.gleam
@@ -47,6 +47,9 @@ import tempo
 import tempo/error as tempo_error
 import tempo/month
 
+/// Starting point of unix timestamps
+pub const unix_epoch = tempo.unix_epoch_date
+
 /// A named day of the week.
 pub type DayOfWeek {
   Sun


### PR DESCRIPTION
Similar to `datetime.unix_epoch` but for the date type