### PR TITLE
Fix first datetime.format() example

### DIFF
--- a/src/tempo/datetime.gleam
+++ b/src/tempo/datetime.gleam
@@ -318,8 +318,8 @@ pub fn describe_parse_error(error: tempo_error.DateTimeParseError) {
 /// ## Examples
 ///
 /// ```gleam
-/// datetime.literal(tempo.Custom("2024-06-21T13:42:11.314-04:00"))
-/// |> datetime.format("ddd @ h:mm A (z)")
+/// datetime.literal("2024-06-21T13:42:11.314-04:00")
+/// |> datetime.format(tempo.Custom("ddd @ h:mm A (z)"))
 /// // -> "Fri @ 1:42 PM (-04)"
 /// ```
 ///


### PR DESCRIPTION
The first example shown on https://hexdocs.pm/gtempo/tempo/datetime.html#format causes a build error when you try to run it. It looks like the cause is a simple typo where `temp.Custom()` was called in the wrong place. The example works once this fix is applied.